### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 #BandsInTownAPI
 Objective-C API wrapper for the BandsInTown API (http://www.bandsintown.com/api/overview).
 ##Installation
-Intstall using Cocoapods! Just add `pod 'BandsintownAPI', '~> 0.1.0'` to your Podfile and run `pod install` on the command line.
+Intstall using CocoaPods! Just add `pod 'BandsintownAPI', '~> 0.1.0'` to your Podfile and run `pod install` on the command line.
 
 __REQUIRED__: In the app delegate, register a name for your app in the application:didFinishLaunchingWithOptions: method
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
